### PR TITLE
Add schema registration support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # heroku_rails_deploy
 
+## v0.3.0
+- Add support for Avro schema registration during deployment.
+- Refuse to deploy when there are uncommitted changes.
+
 ## v0.2.2
 - Fixes bug in getting branch name from executing system command
 

--- a/README.md
+++ b/README.md
@@ -3,8 +3,9 @@
 This gem provides a simple Heroku deploy script for Rails applications. Deploys
 following the following steps:
 
-1. Push code to Heroku
-2. If there are pending migrations, run them and restart the Heroku dynos
+1. Push updated Avro schemas to a schema registry
+2. Push code to Heroku
+3. If there are pending migrations, run them and restart the Heroku dynos
 
 ## Installation
 
@@ -42,6 +43,8 @@ $ bin/deploy --help
 Usage: deploy [options]
     -e, --environment ENVIRONMENT    The environment to deploy to. Must be in production, staging (default production)
     -r, --revision REVISION          The git revision to push. (default HEAD)
+        --register-schemas           Force the registration of Avro schemas when deploying to a non-production environment.
+        --skip-schemas               Skip the registration of Avro schemas when deploying to production.
     -h, --help                       Show this message
 ```
 

--- a/README.md
+++ b/README.md
@@ -43,8 +43,8 @@ $ bin/deploy --help
 Usage: deploy [options]
     -e, --environment ENVIRONMENT    The environment to deploy to. Must be in production, staging (default production)
     -r, --revision REVISION          The git revision to push. (default HEAD)
-        --register-schemas           Force the registration of Avro schemas when deploying to a non-production environment.
-        --skip-schemas               Skip the registration of Avro schemas when deploying to production.
+        --register-avro-schemas      Force the registration of Avro schemas when deploying to a non-production environment.
+        --skip-avro-schemas          Skip the registration of Avro schemas when deploying to production.
     -h, --help                       Show this message
 ```
 

--- a/lib/heroku_rails_deploy/version.rb
+++ b/lib/heroku_rails_deploy/version.rb
@@ -1,3 +1,3 @@
 module HerokuRailsDeploy
-  VERSION = '0.2.2'.freeze
+  VERSION = '0.3.0'.freeze
 end


### PR DESCRIPTION
This changes adds support to deploy any changed `.avsc` files. If the changes include `.avsc` files then it is assumed that the `avro:register_schemas` task is available, but there is no hard dependency on the `avrolution` gem.

By default schemas are only registered for production deployments. The schema registry URL is determined from Heroku for the app.

Additionally, a check was added to prevent deployment when there are uncommitted changes for the repo.

Prime: @jturkel 