### PR TITLE
Display output when running migrations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # heroku_rails_deploy
 
+## v0.4.3
+- Display output while running migration commands.
+
 ## v0.4.2
 - Fix test for pending migrations.
 

--- a/lib/heroku_rails_deploy/deployer.rb
+++ b/lib/heroku_rails_deploy/deployer.rb
@@ -200,7 +200,7 @@ module HerokuRailsDeploy
         output = Bundler.with_clean_env { `#{command}` }
       end
       success = $CHILD_STATUS.success?
-      raise "Command '#{printed_command}' failed" if validate && !success
+      raise "Command '#{printed_command}' failed#{output && output.strip != '' ? ", output: #{output}" : ''}" if validate && !success
       display_output ? success : output
     end
   end

--- a/lib/heroku_rails_deploy/deployer.rb
+++ b/lib/heroku_rails_deploy/deployer.rb
@@ -135,10 +135,7 @@ module HerokuRailsDeploy
     end
 
     def pending_migrations?(app_name)
-      run_heroku_command!(app_name, 'run rake db:abort_if_pending_migrations')
-      false
-    rescue
-      true
+      !run_heroku_command(app_name, 'run rake db:abort_if_pending_migrations')
     end
 
     def run_heroku_command!(app_name, command)
@@ -153,8 +150,11 @@ module HerokuRailsDeploy
         # If we're running a shell command, return the underlying
         # shell command exit code
         cli_command << ' --exit-code'
+        display_output = true
+      else
+        display_output = false
       end
-      run_command(cli_command, validate: validate)
+      run_command(cli_command, validate: validate, display_output: display_output)
     end
 
     def registry_url(app_name)
@@ -187,17 +187,21 @@ module HerokuRailsDeploy
       "git@heroku.com:#{app_name}.git"
     end
 
-    def run_command!(command, print_command: nil, quiet: false)
-      run_command(command, print_command: print_command, quiet: quiet, validate: true)
+    def run_command!(command, print_command: nil, quiet: false, display_output: false)
+      run_command(command, print_command: print_command, quiet: quiet, display_output: display_output, validate: true)
     end
 
-    def run_command(command, print_command: nil, validate: nil, quiet: false)
+    def run_command(command, print_command: nil, validate: nil, quiet: false, display_output: false)
       printed_command = print_command || command
       puts printed_command unless quiet
-      output = Bundler.with_clean_env { `#{command}` }
-      exit_status = $CHILD_STATUS.exitstatus
-      raise "Command '#{printed_command}' failed" if validate && exit_status.nonzero?
-      output
+      if display_output
+        Bundler.with_clean_env { system(command) }
+      else
+        output = Bundler.with_clean_env { `#{command}` }
+      end
+      success = $CHILD_STATUS.success?
+      raise "Command '#{printed_command}' failed" if validate && !success
+      display_output ? success : output
     end
   end
 end

--- a/lib/heroku_rails_deploy/version.rb
+++ b/lib/heroku_rails_deploy/version.rb
@@ -1,3 +1,3 @@
 module HerokuRailsDeploy
-  VERSION = '0.4.3.rc1'.freeze
+  VERSION = '0.4.3'.freeze
 end

--- a/lib/heroku_rails_deploy/version.rb
+++ b/lib/heroku_rails_deploy/version.rb
@@ -1,3 +1,3 @@
 module HerokuRailsDeploy
-  VERSION = '0.4.2'.freeze
+  VERSION = '0.4.3.rc1'.freeze
 end


### PR DESCRIPTION
When this code was changed to use backticks to run all commands, the output when running migrations was lost.

This restores the option to use `system` when running commands, and this is the default for heroku "run" commands.

Prime: @jturkel 