### PR TITLE
Capitalize - require 'English'

### DIFF
--- a/lib/heroku_rails_deploy/deployer.rb
+++ b/lib/heroku_rails_deploy/deployer.rb
@@ -1,7 +1,7 @@
 require 'optparse'
 require 'shellwords'
 require 'yaml'
-require 'english'
+require 'English'
 require 'private_attr'
 
 module HerokuRailsDeploy


### PR DESCRIPTION
Unsure why I'd run into this right now, but case sensitivity seems to matter (the actual library is English with the capital E anyway).  `require` raises an error otherwise.

prime: @jturkel 