### PR TITLE
Use public gem server, updated remote app address, and add active_support dependencies

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,5 @@
 
-source 'https://gems.salsify.com'
+source 'https://rubygems.org'
 
 
 # Specify your gem's dependencies in heroku_rails_deploy.gemspec

--- a/heroku_rails_deploy.gemspec
+++ b/heroku_rails_deploy.gemspec
@@ -21,7 +21,6 @@ Gem::Specification.new do |spec|
 
   spec.add_runtime_dependency 'rails'
   spec.add_runtime_dependency 'private_attr'
-  spec.add_runtime_dependency 'activesupport'
 
   spec.add_development_dependency 'bundler', '~> 1.12'
   spec.add_development_dependency 'rake', '~> 10.0'

--- a/heroku_rails_deploy.gemspec
+++ b/heroku_rails_deploy.gemspec
@@ -21,6 +21,7 @@ Gem::Specification.new do |spec|
 
   spec.add_runtime_dependency 'rails'
   spec.add_runtime_dependency 'private_attr'
+  spec.add_runtime_dependency 'activesupport'
 
   spec.add_development_dependency 'bundler', '~> 1.12'
   spec.add_development_dependency 'rake', '~> 10.0'

--- a/lib/heroku_rails_deploy/deployer.rb
+++ b/lib/heroku_rails_deploy/deployer.rb
@@ -3,6 +3,8 @@ require 'shellwords'
 require 'yaml'
 require 'English'
 require 'private_attr'
+require 'active_support/core_ext/object/try'
+require 'active_support/core_ext/object/blank'
 
 module HerokuRailsDeploy
   class Deployer
@@ -68,7 +70,7 @@ module HerokuRailsDeploy
     end
 
     def production?
-      options.dig(:environment) == PRODUCTION
+      options.try(:environment) == PRODUCTION
     end
 
     private
@@ -113,7 +115,7 @@ module HerokuRailsDeploy
 
     def no_uncommitted_changes!
       uncommitted_changes = run_command!('git status --porcelain', quiet: true)
-      raise "There are uncommitted changes:\n#{uncommitted_changes}" unless uncommitted_changes.empty?
+      raise "There are uncommitted changes:\n#{uncommitted_changes}" unless uncommitted_changes.blank?
     end
 
     def push_code(app_name, revision)

--- a/lib/heroku_rails_deploy/deployer.rb
+++ b/lib/heroku_rails_deploy/deployer.rb
@@ -68,7 +68,7 @@ module HerokuRailsDeploy
     end
 
     def production?
-      options.try(:environment) == PRODUCTION
+      options.dig(:environment) == PRODUCTION
     end
 
     private
@@ -113,7 +113,7 @@ module HerokuRailsDeploy
 
     def no_uncommitted_changes!
       uncommitted_changes = run_command!('git status --porcelain', quiet: true)
-      raise "There are uncommitted changes:\n#{uncommitted_changes}" unless uncommitted_changes.blank?
+      raise "There are uncommitted changes:\n#{uncommitted_changes}" unless uncommitted_changes.empty?
     end
 
     def push_code(app_name, revision)
@@ -184,7 +184,7 @@ module HerokuRailsDeploy
     end
 
     def app_remote(app_name)
-      "git@heroku.com:#{app_name}.git"
+      "https://git.heroku.com/#{app_name}.git"
     end
 
     def run_command!(command, print_command: nil, quiet: false, display_output: false)


### PR DESCRIPTION
1. Updated Gemfile to use public gem server.
2. Explicitly added activesupport's try & blank extensions. We encountered errors on deployment because active_support's `.try` and `.blank?` methods were not loaded.
3. Changed app_remote to use the https:// protocol. This means developers do not need to add SSH keys to heroku. The request is authenticated the same way as pushes to Heroku are usually authenticated.